### PR TITLE
Adds a new @wordpress-block-version docblock to all newly generated blocks

### DIFF
--- a/commands/class-make-block-command.php
+++ b/commands/class-make-block-command.php
@@ -106,6 +106,7 @@ class Make_Block_Command {
 				':BLOCK_TEMPLATE'   => "__DIR__ . '/templates/block.php'",
 				':BLOCK_CLASS_NAME' => $block_class_name,
 				':THEME_SLUG'       => $theme_slug,
+				':BLOCK_VERSION'    => $this->get_block_plugin_version(),
 			)
 		);
 
@@ -264,5 +265,20 @@ class Make_Block_Command {
 		file_put_contents( $blocks_directory_path . '/all.php', PHP_EOL . 'require_once __DIR__ . \'' . $block_class_path . '\';', FILE_APPEND );
 		file_put_contents( $blocks_directory_path . '/all.php', PHP_EOL . $block_class_name . '::init();', FILE_APPEND );
 		file_put_contents( $blocks_directory_path . '/all.php', PHP_EOL, FILE_APPEND );
+	}
+
+	/**
+	 * Determines the version of the block plugin.
+	 *
+	 * @return string
+	 */
+	private function get_block_plugin_version(): string {
+		// Read it from the composer.lock file?
+		$block_version = '1.0.0';
+		if ( class_exists( '\Composer\InstalledVersions' ) ) {
+			$block_version = \Composer\InstalledVersions::getPrettyVersion( 'creode/wordpress-blocks' );
+		}
+
+		return $block_version;
 	}
 }

--- a/commands/class-make-block-command.php
+++ b/commands/class-make-block-command.php
@@ -109,6 +109,7 @@ class Make_Block_Command {
 				':BLOCK_CLASS_NAME' => $block_class_name,
 				':THEME_SLUG'       => $theme_slug,
 				':THEME_NAME'       => $theme->get( 'Name' ),
+				':BLOCK_VERSION'    => $this->get_block_plugin_version(),
 			)
 		);
 

--- a/commands/stubs/class-block.php
+++ b/commands/stubs/class-block.php
@@ -10,6 +10,8 @@ use Creode_Blocks\Block;
 
 /**
  * :BLOCK_LABEL block class.
+ *
+ * @wordpress-block-version :BLOCK_VERSION
  */
 class :BLOCK_CLASS_NAME extends Block {
 

--- a/commands/stubs/class-block.php
+++ b/commands/stubs/class-block.php
@@ -2,6 +2,7 @@
 /**
  * :BLOCK_LABEL block class.
  *
+ * @version :BLOCK_VERSION
  * @package :THEME_SLUG
  */
 

--- a/commands/stubs/class-block.php
+++ b/commands/stubs/class-block.php
@@ -2,7 +2,6 @@
 /**
  * :BLOCK_LABEL block class.
  *
- * @version :BLOCK_VERSION
  * @package :THEME_NAME
  */
 


### PR DESCRIPTION
By adding this to all newly generated blocks we now have the options of knowing which vwersion was used to generate each block. This could help in future when breaking changes are introduced as we have a universal way of targeting blocks and knowing which versions they were created using. This will allow us to build more specific rules.

closes #55 