### PR TITLE
Ignores the stubs folder when building API documentation.

### DIFF
--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -19,6 +19,7 @@
             <include-source>true</include-source>
             <ignore hidden="true" symlinks="true">
                 <path>includes/class-block-cache.php</path>
+                <path>includes/make-block/stubs</path>
             </ignore>
         </api>
     </version>


### PR DESCRIPTION
This will prevent issues where we document dynamic namespaces that are used within block stubs in the make command.